### PR TITLE
eye hostile behaviour - throwing stones

### DIFF
--- a/characters/eye/eye.gd
+++ b/characters/eye/eye.gd
@@ -33,8 +33,6 @@ func attack():
 	add_child(stone_instance)
 	attack_cooldown = true
 	attack_cooldown_timer.start()
-	
-
 
 func _on_attack_cooldown_timer_timeout():
 	attack_cooldown = false

--- a/characters/eye/eye.gd
+++ b/characters/eye/eye.gd
@@ -1,7 +1,40 @@
 extends CharacterBody2D
 
-@onready var laser = $Laser
 @export var player: CharacterBody2D
+@export var stone_throw_margin: float = 0.4 # this is used to prevent stone from spawning inside the Eye collider, but there are other ways to do that.
+@export var stone_throw_strength: float = 10.0
+var hostile: bool = false
+var attack_cooldown: bool = false
+@onready var laser = $Laser
+@onready var attack_cooldown_timer = $AttackCooldownTimer
+@onready var stone_scene = preload("res://items/stone/stone.tscn")
 
-func _physics_process(delta):
+func _physics_process(_delta):
+	scout()
+	attack()
+		
+func scout():
 	laser.look_at(player.position)
+	
+	if laser.get_collider():
+		if laser.get_collider().name == "Player":
+			hostile = true
+		else:
+			hostile = false
+	else:
+		hostile = false
+		
+func attack():
+	if not hostile or attack_cooldown:
+		return
+	var stone_instance = stone_scene.instantiate()
+	stone_instance.position = (player.position - position) * stone_throw_margin # spwaning rock outside Eye collider but in the direction of player.
+	stone_instance.impulse = (player.position - position) * stone_throw_strength
+	add_child(stone_instance)
+	attack_cooldown = true
+	attack_cooldown_timer.start()
+	
+
+
+func _on_attack_cooldown_timer_timeout():
+	attack_cooldown = false

--- a/characters/eye/eye.tscn
+++ b/characters/eye/eye.tscn
@@ -4,24 +4,29 @@
 [ext_resource type="Texture2D" uid="uid://d0j7qv1enbv2q" path="res://icon.svg" id="1_fot5g"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_taxr8"]
-size = Vector2(60, 60)
+size = Vector2(128, 128)
 
 [node name="Eye" type="CharacterBody2D"]
 script = ExtResource("1_a5ab8")
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-shape = SubResource("RectangleShape2D_taxr8")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 modulate = Color(0.639216, 0.337255, 1, 1)
 texture = ExtResource("1_fot5g")
 
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("RectangleShape2D_taxr8")
+
 [node name="Laser" type="RayCast2D" parent="."]
-target_position = Vector2(292, -1)
+target_position = Vector2(256, 0)
 
 [node name="Sprite2D" type="Sprite2D" parent="Laser"]
 modulate = Color(1, 1, 0, 1)
-position = Vector2(30, 0)
+position = Vector2(128, 0)
 rotation = 1.5708
-scale = Vector2(0.03125, 0.5)
+scale = Vector2(0.05, 2)
 texture = ExtResource("1_fot5g")
+
+[node name="AttackCooldownTimer" type="Timer" parent="."]
+wait_time = 2.0
+
+[connection signal="timeout" from="AttackCooldownTimer" to="." method="_on_attack_cooldown_timer_timeout"]

--- a/items/stone/stone.gd
+++ b/items/stone/stone.gd
@@ -1,0 +1,11 @@
+extends RigidBody2D
+
+var target_position: Vector2
+var impulse: Vector2 = Vector2.ZERO
+
+func _ready():
+	look_at(target_position)
+	apply_central_impulse(impulse)
+
+func _on_destruction_timer_timeout():
+	queue_free()

--- a/items/stone/stone.gd
+++ b/items/stone/stone.gd
@@ -1,10 +1,8 @@
 extends RigidBody2D
 
-var target_position: Vector2
 var impulse: Vector2 = Vector2.ZERO
 
 func _ready():
-	look_at(target_position)
 	apply_central_impulse(impulse)
 
 func _on_destruction_timer_timeout():

--- a/items/stone/stone.tscn
+++ b/items/stone/stone.tscn
@@ -1,0 +1,26 @@
+[gd_scene load_steps=4 format=3 uid="uid://rqdmkp4x6l7u"]
+
+[ext_resource type="Script" path="res://items/stone/stone.gd" id="1_7dh0y"]
+[ext_resource type="Texture2D" uid="uid://d0j7qv1enbv2q" path="res://icon.svg" id="1_wju7m"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_jlddo"]
+radius = 16.0
+
+[node name="Stone" type="RigidBody2D"]
+gravity_scale = 0.0
+script = ExtResource("1_7dh0y")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+position = Vector2(0, 8.34465e-07)
+scale = Vector2(0.25, 0.25)
+texture = ExtResource("1_wju7m")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("CircleShape2D_jlddo")
+
+[node name="DestructionTimer" type="Timer" parent="."]
+wait_time = 2.0
+one_shot = true
+autostart = true
+
+[connection signal="timeout" from="DestructionTimer" to="." method="_on_destruction_timer_timeout"]


### PR DESCRIPTION
the Eye begins throwing stones (rigid bodies) towards the exact center of the player every 3 seconds whenever they are colliding with the Raycast.
it currently doesn't do damage, that would need to modify the player node and i made it so that only the eye node is modified, i'll implement damage in a separate branch.